### PR TITLE
refactor hand functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,21 @@
 # Change Log
 
 TODO:
-- refactor "hand" functions: use :hand slot instead 
 - damage bonus for eq weapons with matching weaknesses: maybe add flat bonus, or bonus to weapon damage instead of total dmg? 
 - make player damage a range instead of flat value
 - make enemy damage and health a range instead of flat value 
 - randomize how much loot can be at locations
-- make slot visible on inv menu
+- make slot visible on inv menu?
 - only list damage types you have when fighting once
 - reduce enemy and items with weaknesses & special dmg types
 - remove pauses after fighting
 
 Longer TODO:
 - add items that grant resistances to dmg types
+- add two-handed weapons
+
+## [0.3.2] - 24-11-2023
+Removed "-Hand" functions from Model
 
 ## [0.3.1] - 10-11 2023
 Refactoring Model: 

--- a/resources/title.txt
+++ b/resources/title.txt
@@ -33,4 +33,4 @@
  
  
  
- The Shadow Over Darkmoor (c) 2019-2020 CM Rutz
+ (c) Casper Rutz

--- a/src/darkmoor/controller.clj
+++ b/src/darkmoor/controller.clj
@@ -129,8 +129,8 @@
     (case command
       :exit    player 
       :help    (do (open-help) (fight-inv-menu player map-stack loc-info enemy))
-      :equip   (fight-inv-menu (equip-item-hand player item-id) map-stack loc-info enemy)
-      :unequip (fight-inv-menu (unequip-item-hand player item-id) map-stack loc-info enemy))))
+      :equip   (fight-inv-menu (equip-item player item-id) map-stack loc-info enemy)
+      :unequip (fight-inv-menu (unequip-item player item-id) map-stack loc-info enemy))))
 
 (defn parse-player-attack-input [player]
   "Getting and parsing user input for player-attack-menu"

--- a/src/darkmoor/model/model.clj
+++ b/src/darkmoor/model/model.clj
@@ -58,28 +58,8 @@
 (defn get-hands [player]
   (:hand (:eq player)))
 
-(defn get-item-in-r-hand [player r-hand?]
-  (if r-hand? (nth (get-hands player) 0) (nth (get-hands player) 1)))
-
-; l-hand and r-hand functions are specified due to
-; extra checks that need to happen regarding weapons
-(defn get-r-hand [player]
-  (get-item (:r-hand (:eq player))))
-
-(defn set-r-hand [player value]
-  (assoc-in player [:eq :r-hand] value))
-
-(defn get-l-hand [player]
-  (get-item (:l-hand (:eq player))))
-
-(defn set-l-hand [player value]
-  (assoc-in player [:eq :l-hand] value))
-
-(defn item-eq-in-r-hand? [player id]
-  (= (get-r-hand player) (get-item id)))
- 
-(defn item-eq-in-l-hand? [player id]
-  (= (get-l-hand player) (get-item id)))
+(defn get-id-in-hand [player id]
+  (some #{id} (get-hands player)))
 
 (defn get-item-slot [id]
   ; gets slot this item should be equipped in
@@ -90,24 +70,21 @@
   (get-item (slot (:eq player))))
 
 (defn is-item-eq? [player slot id]
-  (= (get-eq-slot player slot) (get-item id)))
+  (if (= slot :hand)
+    (and (not (nil? id)) (= (get-id-in-hand player id) id))
+    (and (not (nil? id)) (= (get-eq-slot player slot) (get-item id)))))
 
-(defn set-eq-slot [player slot id] 
+(defn set-eq-slot [player slot old-id new-id] 
   ; sets item info in specified equipment slot
-  (assoc-in player [:eq slot] id))
+  (if (= slot :hand)
+    ; on hands, need to remove old id from vector first
+    (let [[no-matches one-match] (split-with (partial not= old-id) (get-hands player))]
+      (assoc-in player [:eq :hand] (conj (concat no-matches (rest one-match)) new-id)))
+    (assoc-in player [:eq slot] new-id)))
 
-(defn get-l-hand-id [player]
-  ; get id of item currently equipped in l hand
-  (:l-hand (:eq player)))
-  
 (defn get-inv-item-count [player id]
   ; how many of this sepcific item are in the player's inventory
   (get (:inv player) id))
-
-(defn item-already-in-hand [player id]
-  (and (or (item-eq-in-r-hand? player id)
-           (item-eq-in-l-hand? player id))
-       (= (get-inv-item-count player id) 1)))
 
 (defn set-inv-item [player id value]
   ; sets inventory count of specified item to specific value
@@ -129,9 +106,6 @@
     (set-loot-item-count player map-stack loc-info id (inc current-count))
     (set-loot-item-count player map-stack loc-info id 1)))
 
-; NOTE: "hand" functions are needed because items equipped in r-hand or l-hand  
-;       are tagged with :hand, not the slot they're equipped in
-
 (defn player-add-hp-dmg [player id]
   (let [item (get-item id)]
   (assoc player :health (map + (:health player) (repeat 2 (:health item)))
@@ -142,94 +116,43 @@
   (assoc player :health (map - (:health player) (repeat 2 (:health item)))
                 :damage (- (:damage player) (:damage item)))))
 
-(defn unequip-item-hand [player id]
-  "For unequipping a weapon at player's command:
-   sets slot item was equipped in to nil, and subtracts
-   item's stats from player's."
-  (if (item-eq-in-r-hand? player id)
-    (let [uneq-player (player-sub-hp-dmg player id)]
-      (set-r-hand uneq-player nil))
-    (if (item-eq-in-l-hand? player id)
-      (let [uneq-player (player-sub-hp-dmg player id)]
-        (set-l-hand uneq-player nil))
+(defn unequip-item [player id]
+  (let [slot (get-item-slot id)]
+    (if (is-item-eq? player slot id)
+      (set-eq-slot (player-sub-hp-dmg player id) slot id nil)
       player)))
 
-(defn unequip-item [player id]
-  ; subtracts item's dmg and health and then unequips
-  (let [item-slot (get-item-slot id)]
-    (if (= item-slot :hand)
-      (unequip-item-hand player id)
-      (if (is-item-eq? player item-slot id)
-        (set-eq-slot (player-sub-hp-dmg player id) item-slot nil)
-        player))))
+(defn get-id [id]
+ ; id might be a vector or an int
+  (if (int? id)
+    id
+    (if (some nil? id)
+      nil
+      (second id))))
 
-(defn unequip-eq-hand [player]
-  "For unequipping item in l-hand or r-hand before equipping
-   some other item in that slot."
-  (let [uneq-player (player-sub-hp-dmg player (get-l-hand-id player))]
-    (set-l-hand uneq-player nil)))
+(defn get-eq-item-id [player slot]
+  (let [maybe-id-vector (slot (:eq player))]
+    (get-id maybe-id-vector)))
 
-(defn unequip-eq [player id]
-  ; to be used when equipping one item involves unequipping another
-  ; unequips specified item and then returns player
-  (let [old-id ((get-item-slot id) (:eq player))]
-    (set-eq-slot (player-sub-hp-dmg player old-id) (get-item-slot id) nil)))
-
-(defn equip-item-hand [player id]
-  "Adds an item id to an item slot in player's equipped list
-   and updates player stats. If slot is not open, unequips 
-   item in slot before adding item stats to player. Does nothing
-   if item is already equipped in a hand and only 1 of item is
-   in inventory."
-  (if (item-already-in-hand player id)
-    player
-    ;new stats for player (used if unequip not needed)
-    (let [new-stats-player (player-add-hp-dmg player id)]
-      (if (get-r-hand player)
-        (if (get-l-hand player)
-          ;both hands are full, so unequip 2nd hand
-          (let [uneq-player (unequip-eq-hand player)]
-            ;then add item's health to player
-            (let [new-player (player-add-hp-dmg uneq-player id)]
-              ;and eq new item
-              (set-l-hand new-player id)))
-          (set-l-hand new-stats-player id))
-        (set-r-hand new-stats-player id)))))
-
-(defn equip-item [player id]
-  (let [item-slot (get-item-slot id)]
-    (if (= item-slot :hand)
-      (equip-item-hand player id)
-      (if (item-slot (:eq player))
-        ;unequip item if slot is taken
-        (set-eq-slot (player-add-hp-dmg (unequip-eq player id) id) item-slot id)
-        (set-eq-slot (player-add-hp-dmg player id) item-slot id)))))
-
-(defn drop-item-hand [player map-stack loc-info id]
-  "Removes an item from player's inventory, and 
-   adds to location. If item was equipped and only 1 was 
-   in inventory, unequips first."
-  (if (and (or (item-eq-in-r-hand? player id) 
-               (item-eq-in-l-hand? player id))
-           (= 1 (get-inv-item-count player id)))
-    [(let [uneq-player (unequip-item player id)]
-       (set-inv-item uneq-player id (dec (get-inv-item-count player id))))
-     (add-to-loc player map-stack loc-info id)]
-    [(set-inv-item player id (dec (get-inv-item-count player id)))
-     (add-to-loc player map-stack loc-info id)]))
+(defn equip-item [player new-id]
+  (let [slot (get-item-slot new-id)
+        old-id (get-eq-item-id player slot)]
+    (if (is-item-eq? player slot old-id)
+      ;unequip item if slot is taken
+      (set-eq-slot (player-add-hp-dmg (unequip-item player old-id) new-id) slot nil new-id)
+      (set-eq-slot (player-add-hp-dmg player new-id) slot nil new-id))))
 
 (defn drop-item [player map-stack loc-info id]
-  (let [item-slot (get-item-slot id)
-        loc-with-item (add-to-loc player map-stack loc-info id)]
-    (if (= item-slot :hand)
-      (drop-item-hand player map-stack loc-info id)
-      ; if item is equipped and there's only 1 in inventory, then unequip
-      (if (and (is-item-eq? player item-slot id) 
-               (= 1 (get-inv-item-count player id)))
-        [(set-inv-item (unequip-item player id) id (dec (get-inv-item-count player id)))
-         loc-with-item]
-        [(set-inv-item player id (dec (get-inv-item-count player id)))
-         loc-with-item]))))
+  (let [slot (get-item-slot id)
+        inv-item-count (get-inv-item-count player id)
+        loc-with-item (add-to-loc player map-stack loc-info id)
+        dec-inv-item-count (dec inv-item-count)]
+    (if (and (is-item-eq? player slot id) 
+             (= 1 inv-item-count))
+      [(set-inv-item (unequip-item player id) id dec-inv-item-count)
+       loc-with-item]
+      [(set-inv-item player id dec-inv-item-count)
+       loc-with-item])))
     
 ;LOOT
 

--- a/src/darkmoor/model/player-data.clj
+++ b/src/darkmoor/model/player-data.clj
@@ -13,8 +13,6 @@
         :fingers nil
         :boots nil
         :hand [2 nil]
-        :r-hand 2
-        :l-hand nil
         :potion nil} 
    :row (rand-int 4) ; player's positon
    :col (rand-int 3)

--- a/src/darkmoor/view.clj
+++ b/src/darkmoor/view.clj
@@ -115,10 +115,9 @@
 
         ;is it equipped?
        (if (= (:slot item) :hand)
-          (if (or (item-eq-in-r-hand? player k)
-                  (item-eq-in-l-hand? player k))
-            (print " ********   ")
-            (print "            "))
+          (if (get-id-in-hand player k) 
+              (print " ********   ")
+              (print "            "))
           ;get the id of the eq slot that's the
           (if (is-item-eq? player (get-item-slot k) k)
             (print " ********   ")
@@ -304,9 +303,7 @@
              (= :hand (get-item-slot k)))
       (do
 
-        ;is it equipped?
-        (if (or (item-eq-in-r-hand? player k)
-                (item-eq-in-l-hand? player k))
+        (if (get-id-in-hand player k) 
           (print " ********   ")
           (print "            "))
 


### PR DESCRIPTION
- Remove old `-hand` equip/unequip/drop inventory functions and integrate functionality into existing functions
- Use `:hand` inventory slot instead of `:r-hand` and `:l-hand` slots